### PR TITLE
fixed paddle glitching

### DIFF
--- a/src/js/game.js
+++ b/src/js/game.js
@@ -48,8 +48,8 @@ document.addEventListener("DOMContentLoaded", function () {
     let gameInterval;
     document.addEventListener("keydown", keyDownHandler, false);
     document.addEventListener("keyup", keyUpHandler, false);
-    canvas.addEventListener("touchstart", touchStartHandler, false);
-    canvas.addEventListener("touchmove", touchMoveHandler, false);
+    canvas.addEventListener("touchstart", touchStartHandler, { passive: false });
+    canvas.addEventListener("touchmove", touchMoveHandler, { passive: false });
     function keyDownHandler(e) {
         if (e.key == "Right" || e.key == "ArrowRight") {
             rightPressed = true;
@@ -67,21 +67,24 @@ document.addEventListener("DOMContentLoaded", function () {
         }
     }
     function touchStartHandler(e) {
-        const touchX = e.touches[0].clientX;
-        if (touchX > canvas.width / 2) {
-            rightPressed = true;
-        }
-        else {
-            leftPressed = true;
+        e.preventDefault();
+        const touchX = e.touches[0].clientX - canvas.offsetLeft;
+        paddleX = touchX - paddleWidth / 2;
+        
+        if (paddleX < 0) {
+            paddleX = 0;
+        } else if (paddleX + paddleWidth > canvas.width) {
+            paddleX = canvas.width - paddleWidth;
         }
     }
     function touchMoveHandler(e) {
-        const touchX = e.touches[0].clientX;
+        e.preventDefault();
+        const touchX = e.touches[0].clientX - canvas.offsetLeft;
         paddleX = touchX - paddleWidth / 2;
+        
         if (paddleX < 0) {
             paddleX = 0;
-        }
-        else if (paddleX + paddleWidth > canvas.width) {
+        } else if (paddleX + paddleWidth > canvas.width) {
             paddleX = canvas.width - paddleWidth;
         }
     }
@@ -267,3 +270,4 @@ document.addEventListener("DOMContentLoaded", function () {
     window.addEventListener('resize', resizeCanvas, false);
     resizeCanvas();
 });
+


### PR DESCRIPTION
Yo, I've been working on fixing the touch controls in our Breakout game. Here's what I did:

1. Changed the touchStartHandler and touchMoveHandler functions:

-> Now they directly set the paddle's position (paddleX) based on where you touch. -> Removed the rightPressed and leftPressed stuff because we don't need it for touch. -> Added e.preventDefault() to stop the screen from scrolling when you play.


2. Updated how we calculate touch position:

-> Now using e.touches[0].clientX - canvas.offsetLeft to get the right position even if the game isn't at the top of the page.


-> Added checks to keep the paddle on screen:
javascriptCopyif (paddleX < 0) {
    paddleX = 0;
} else if (paddleX + paddleWidth > canvas.width) {
    paddleX = canvas.width - paddleWidth;
}

3. Changed the event listeners:

-> Now it looks like this:
javascriptCopycanvas.addEventListener("touchstart", touchStartHandler, { passive: false }); canvas.addEventListener("touchmove", touchMoveHandler, { passive: false });

->The { passive: false } part lets preventDefault() work properly.


The paddle should move smoothly with your finger now, and it shouldn't glitch out anymore.

Also, Could you please test it out and let me know if it works better? I'm still learning, so any feedback would be super helpful. Thanks!